### PR TITLE
完善账号状态检查，正确显示翻车状态

### DIFF
--- a/backend/openai/api/auth/session.go
+++ b/backend/openai/api/auth/session.go
@@ -49,7 +49,7 @@ func Session(r *ghttp.Request) {
 	sessionJson.Dump()
 
 	detail := sessionJson.Get("detail").String()
-	if gstr.Contains(detail, "RefreshAccessTokenError") {
+	if gstr.Contains(detail, "RefreshAccessTokenError") || gstr.Contains(detail, "Unauthorized") {
 		utility.CloseCar(ctx, carid)
 		r.Response.Status = 401
 		r.Response.WriteJson(gjson.New(errSessionStr))


### PR DESCRIPTION
针对 https://github.com/xyhelper/chatgpt-share-server/issues/32 问题，我在`/api/auth/session`逻辑中增加了`/refreshsession`结果为`Unauthorized`的情况判断，解决了问题。